### PR TITLE
Add REST API endpoint for list of Scans for given Dataset

### DIFF
--- a/backend/medtagger/api/pagination.py
+++ b/backend/medtagger/api/pagination.py
@@ -1,0 +1,13 @@
+"""Module that contains helpers related to pagination in the REST API."""
+from flask_restplus import fields
+
+from medtagger.api import api
+
+
+PAGINATION = {
+    'pagination': fields.Nested(api.model('Pagination', {
+        'page': fields.Integer(description='Page number'),
+        'per_page': fields.Integer(description='Number of entries per page'),
+        'total': fields.Integer(description='Total numer of entries'),
+    })),
+}

--- a/backend/medtagger/api/scans/business.py
+++ b/backend/medtagger/api/scans/business.py
@@ -277,6 +277,17 @@ def add_new_slice(scan_id: ScanID, image: bytes) -> Slice:
     return _slice
 
 
+def get_paginated_scans(dataset_key: str = None, page: int = 1, per_page: int = 25) -> Tuple[List[Scan], int]:
+    """Get paginated Scans for given filters.
+
+    :param dataset_key: (optional) key for Dataset that should be used as a filter
+    :param page: (optional) page number which should be fetched
+    :param per_page: (optional) number of entries per page
+    :return: tuple of list of Scans and total number of entries available
+    """
+    return ScansRepository.get_paginated_scans(dataset_key=dataset_key, page=page, per_page=per_page)
+
+
 def get_scan(scan_id: ScanID) -> Scan:
     """Return Scan for given scan_id.
 

--- a/backend/medtagger/api/scans/serializers.py
+++ b/backend/medtagger/api/scans/serializers.py
@@ -2,7 +2,9 @@
 from flask_restplus import reqparse, fields
 
 from medtagger.api import api
+from medtagger.api.pagination import PAGINATION
 from medtagger.definitions import ScanStatus, LabelVerificationStatus
+
 
 in__new_scan = api.model('New Scan model', {
     'dataset': fields.String(description='Dataset', required=True),
@@ -103,6 +105,12 @@ out__scan = api.model('Scan model', {
                                        attribute='declared_number_of_slices'),
 })
 
+out__scans = api.model('List of Scans model', {
+    'scans': fields.List(fields.Nested(out__scan)),
+})
+
+out__scans_paginated = api.inherit('Paginated list of Scans model', out__scans, PAGINATION)
+
 out__random_scan = api.inherit('Random Scan model', out__scan, {
     'predefined_label_id': fields.String(description='Predefined Label\'s ID'),
 })
@@ -123,6 +131,11 @@ out__new_scan = api.model('Newly created Scan model', {
 out__new_slice = api.model('Newly created Slice model', {
     'slice_id': fields.String(description='Slice\'s ID', attribute='id'),
 })
+
+args__scans = reqparse.RequestParser()
+args__scans.add_argument('dataset_key', type=str, help='Dataset\'s key')
+args__scans.add_argument('page', type=int, default=1, help='Page which should be fetched')
+args__scans.add_argument('per_page', type=int, default=25, help='Number of items per Page which should be fetched')
 
 args__random_scan = reqparse.RequestParser()
 args__random_scan.add_argument('task', type=str, required=True, help='Task\'s key')

--- a/backend/medtagger/api/scans/service_rest.py
+++ b/backend/medtagger/api/scans/service_rest.py
@@ -34,7 +34,11 @@ class Scans(Resource):
         args = serializers.args__scans.parse_args(request)
         dataset_key = args.dataset_key
         page = args.page
+        if page < 1:
+            raise InvalidArgumentsException('Page cannot be smaller than 1.')
         per_page = args.per_page
+        if per_page > 100:
+            raise InvalidArgumentsException('Cannot fetch more than 100 entries at once.')
 
         scans, total = business.get_paginated_scans(dataset_key=dataset_key, page=page, per_page=per_page)
         return {

--- a/backend/medtagger/api/scans/service_rest.py
+++ b/backend/medtagger/api/scans/service_rest.py
@@ -24,6 +24,31 @@ class Scans(Resource):
     @staticmethod
     @login_required
     @role_required('doctor', 'admin')
+    @scans_ns.expect(serializers.args__scans)
+    @scans_ns.marshal_with(serializers.out__scans_paginated)
+    @scans_ns.doc(security='token')
+    @scans_ns.doc(description='Return list of available scans.')
+    @scans_ns.doc(responses={200: 'Success'})
+    def get() -> Any:
+        """Get list of all Scans."""
+        args = serializers.args__scans.parse_args(request)
+        dataset_key = args.dataset_key
+        page = args.page
+        per_page = args.per_page
+
+        scans, total = business.get_paginated_scans(dataset_key=dataset_key, page=page, per_page=per_page)
+        return {
+            'scans': scans,
+            'pagination': {
+                'total': total,
+                'page': page,
+                'per_page': per_page,
+            },
+        }
+
+    @staticmethod
+    @login_required
+    @role_required('doctor', 'admin')
     @scans_ns.expect(serializers.in__new_scan)
     @scans_ns.marshal_with(serializers.out__new_scan)
     @scans_ns.doc(security='token')

--- a/backend/medtagger/repositories/scans.py
+++ b/backend/medtagger/repositories/scans.py
@@ -1,5 +1,5 @@
 """Module responsible for definition of ScansRepository."""
-from typing import List
+from typing import List, Tuple
 
 from sqlalchemy.sql.expression import func
 
@@ -7,6 +7,25 @@ from medtagger.database import db_session
 from medtagger.database.models import Dataset, Scan, Slice, User, Label, Task, datasets_tasks
 from medtagger.definitions import ScanStatus, SliceStatus
 from medtagger.types import ScanID
+
+
+def get_paginated_scans(dataset_key: str = None, page: int = 1, per_page: int = 25) -> Tuple[List[Scan], int]:
+    """Fetch and return all Scans filtered by given parameters.
+
+    :param dataset_key: (optional) key for Dataset that should be used as a filter
+    :param page: (optional) page number which should be fetched
+    :param per_page: (optional) number of entries per page
+    :return: tuple of list of Scans and total number of entries available
+    """
+    query = Scan.query
+    if dataset_key:
+        query = query.join(Dataset)
+        query = query.filter(Dataset.key == dataset_key)
+    query = query.order_by(Scan.id)
+
+    scans = query.limit(per_page).offset((page - 1) * per_page).all()
+    total_scans = query.count()
+    return scans, total_scans
 
 
 def get_all_scans() -> List[Scan]:

--- a/backend/tests/functional_tests/api/__init__.py
+++ b/backend/tests/functional_tests/api/__init__.py
@@ -1,0 +1,1 @@
+"""Module responsible for MedTagger's API tests."""

--- a/backend/tests/functional_tests/api/scans/__init__.py
+++ b/backend/tests/functional_tests/api/scans/__init__.py
@@ -1,0 +1,1 @@
+"""Module responsible for MedTagger's Scans API tests."""

--- a/backend/tests/functional_tests/api/scans/test_fetching_scans.py
+++ b/backend/tests/functional_tests/api/scans/test_fetching_scans.py
@@ -1,0 +1,63 @@
+"""Tests for REST API for fetching metadata about Scans."""
+import json
+from typing import Any
+
+from medtagger.repositories import (
+    datasets as DatasetsRepository,
+    scans as ScansRepository,
+)
+
+from tests.functional_tests import get_api_client, get_headers
+from tests.functional_tests.conftest import get_token_for_logged_in_user
+
+
+def test_get_paginated_scans(prepare_environment: Any) -> None:
+    """Test for fetching Scans in the paginated way."""
+    api_client = get_api_client()
+    user_token = get_token_for_logged_in_user('admin')
+
+    # Step 1. Prepare a structure for the test
+    dataset = DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
+
+    # Step 2. Add example Scans to the system
+    for _ in range(50):
+        ScansRepository.add_new_scan(dataset, number_of_slices=3)
+
+    # Step 3. Fetch them with MedTagger REST API
+    response = api_client.get('/api/v1/scans?dataset_key=KIDNEYS', headers=get_headers(token=user_token))
+    assert response.status_code == 200
+    json_response = json.loads(response.data)
+    assert json_response['pagination']['page'] == 1
+    assert json_response['pagination']['per_page'] == 25
+    assert json_response['pagination']['total'] == 50
+    assert len(json_response['scans']) == 25
+
+    # Step 4. Fetch the next page with different size
+    response = api_client.get('/api/v1/scans?dataset_key=KIDNEYS&page=2&per_page=10',
+                              headers=get_headers(token=user_token))
+    assert response.status_code == 200
+    json_response = json.loads(response.data)
+    assert json_response['pagination']['page'] == 2
+    assert json_response['pagination']['per_page'] == 10
+    assert json_response['pagination']['total'] == 50
+    assert len(json_response['scans']) == 10
+
+
+def test_get_paginated_scans_by_volunteer(prepare_environment: Any) -> None:
+    """Test for fetching Scans in the paginated way by volunteers."""
+    api_client = get_api_client()
+    user_token = get_token_for_logged_in_user('volunteer')
+
+    # Step 1. Prepare a structure for the test
+    dataset = DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
+
+    # Step 2. Add example Scans to the system
+    for _ in range(50):
+        ScansRepository.add_new_scan(dataset, number_of_slices=3)
+
+    # Step 3. Fetch them with MedTagger REST API
+    response = api_client.get('/api/v1/scans?dataset_key=KIDNEYS', headers=get_headers(token=user_token))
+    assert response.status_code == 403
+    json_response = json.loads(response.data)
+    assert json_response['message'] == 'Access forbidden'
+    assert json_response['details'] == 'You don\'t have required roles to access this method.'


### PR DESCRIPTION
## Proposed Changes

  - Add new endpoint that returns list of available Scans for given Dataset,
  - Add unified pagination model that can be used across different endpoints,
  - Query SQL database for all Scans.

## API changes

New REST API endpoint:

**GET** `http://localhost:51000/api/v1/scans?dataset_key=LUNGS&page=1&per_page=25`
**Required Roles:** Doctor or Admin
**Example output:**
```json
{
  "pagination": {
    "page": 1,
    "per_page": 25,
    "total": 1
  },
  "scans": [
    {
      "scan_id": "454360b7-8e11-425a-b694-96093d4aa8e1",
      "width": 512,
      "height": 512,
      "status": "AVAILABLE",
      "number_of_slices": 110
    }
  ]
}
```

## Additional comment

Later, we will be able to extend this endpoint with information about entered Labels. I didn't have done it in order to keep this patch simple.