### PR TITLE
Fixed bug when username was too short, switched icons on tutorial page

### DIFF
--- a/frontend/src/app/pages/home-page/home-page.component.scss
+++ b/frontend/src/app/pages/home-page/home-page.component.scss
@@ -11,6 +11,7 @@
 
 .account {
     &-button {
+        min-width: 140px;
         position: relative;
         border-radius: 5px;
         transition: background-color 0.2s ease-in, border-radius 0.2s;

--- a/frontend/src/app/pages/tutorial-page/tutorial-page.component.html
+++ b/frontend/src/app/pages/tutorial-page/tutorial-page.component.html
@@ -10,7 +10,7 @@
         <div class="tutorial-info">
             <button mat-raised-button class="tutorial-info__next" (click)="endTutorial()" data-cy="end-tutorial"
                     color="primary">
-                <mat-icon>label_outline</mat-icon>
+                <mat-icon>home</mat-icon>
                 Proceed to home page
             </button>
             <mat-checkbox class="tutorial-info__hide" [formControl]="doNotShowAgain" data-cy="not-show">


### PR DESCRIPTION
## Proposed Changes

  - Fixed issue when username was too short - it resulted in weird text shifting in dropdown menu.

![screenshot from 2019-03-06 00-21-04](https://user-images.githubusercontent.com/17303358/53844805-39018500-3fa7-11e9-9ecf-8a77719b4a0c.png)
![screenshot from 2019-03-06 00-20-49](https://user-images.githubusercontent.com/17303358/53844815-3d2da280-3fa7-11e9-9a4c-cd5dd723d07f.png)

  - Updated icon on the tutorial page

![screenshot from 2019-03-06 00-32-35](https://user-images.githubusercontent.com/17303358/53844888-6e0dd780-3fa7-11e9-8463-3d5c61f2d443.png)
![screenshot from 2019-03-06 00-34-45](https://user-images.githubusercontent.com/17303358/53844955-a7dede00-3fa7-11e9-9eb1-1dbec2f0fcf8.png)


