### PR TITLE
Stabilize SQL Connection Pool and remove pickling in Celery

### DIFF
--- a/backend/medtagger/database/__init__.py
+++ b/backend/medtagger/database/__init__.py
@@ -30,7 +30,7 @@ class MedTaggerBase:  # pylint: disable=too-few-public-methods
 configuration = AppConfiguration()
 db_uri = configuration.get('db', 'database_uri')
 db_pool_size = configuration.getint('db', 'connection_pool_size')
-engine = create_engine(db_uri, pool_size=db_pool_size, convert_unicode=True)
+engine = create_engine(db_uri, pool_size=db_pool_size, convert_unicode=True, pool_pre_ping=True)
 session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
 
 convention = {

--- a/backend/medtagger/workers/celery_configuration.py
+++ b/backend/medtagger/workers/celery_configuration.py
@@ -6,6 +6,7 @@ from typing import List, Any
 from celery.signals import setup_logging, worker_process_init
 
 from medtagger.config import AppConfiguration
+from medtagger.database import engine
 from medtagger.storage import create_connection
 
 
@@ -30,12 +31,9 @@ def setup_logging_handler(*args: List[Any], **kwargs: List[Any]) -> None:  # pyl
 def process_initialization(*args: List[Any], **kwargs: List[Any]) -> None:  # pylint: disable=unused-argument
     """Initialize given Celery process."""
     create_connection()
+    engine.dispose()  # Recreate SQL Pool
 
 
 configuration = AppConfiguration()
 broker_url = configuration.get('celery', 'broker', fallback='pyamqp://guest:guest@localhost//')
 imports = get_all_modules_with_tasks()
-
-# The default serializers for Celery >=3.1 is JSON, which doesn't make sense if we send binary data to task
-task_serializer = 'pickle'
-accept_content = {'pickle'}


### PR DESCRIPTION
## Proposed Changes

  - Recreate SQL Connection Pool after fork in uWSGI,
  - Add pre ping to be sure that our connection works properly,
  - Remove unneded pickling - should be more stable, faster and a little bit more secure.