### PR TITLE
Use "--parallel" in Docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       name: "Backend - Linters & Unit Tests"
       script:
         - python3 .travis/run_tests_if_subproject_changed.py backend --command="
-           docker-compose build medtagger_backend_rest medtagger_backend_websocket medtagger_backend_worker medtagger_backend_database_migrations &&
+           docker-compose build --parallel medtagger_backend_rest medtagger_backend_websocket medtagger_backend_worker medtagger_backend_database_migrations &&
            docker-compose run --no-deps medtagger_backend_rest /bin/bash -c \"make install_dev_packages && make test\""
 
     # Backend - functional tests

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ WORKERS_PID_FILE = workers.pid
 #
 
 docker_build:
-	docker-compose build medtagger_backend_rest medtagger_frontend medtagger_backend_websocket medtagger_backend_worker medtagger_backend_database_migrations
+	docker-compose build --parallel medtagger_backend_rest medtagger_frontend medtagger_backend_websocket medtagger_backend_worker medtagger_backend_database_migrations
 
 docker_push_stable: docker_push_version
 	docker push medtagger/frontend_ui:latest
@@ -74,7 +74,8 @@ e2e:
 	echo "E2E Tests passed!"
 
 e2e_docker:
-	docker-compose -f $(E2E_DOCKER_COMPOSE) up --build -d
+	docker-compose -f $(E2E_DOCKER_COMPOSE) build --parallel
+	docker-compose -f $(E2E_DOCKER_COMPOSE) up -d
 	cd e2e && npm install
 	@if ! make e2e__run_docker; then\
 	    docker-compose -f $(E2E_DOCKER_COMPOSE) logs e2e_medtagger_backend_database_migrations;\


### PR DESCRIPTION
## Proposed Changes

  - Speed up building multiple Docker images by using `--parallel` flag.

## Additional comment

It was introduced a while ago in [version 1.24.0](https://github.com/docker/compose/blob/master/CHANGELOG.md#1240-2019-03-28).