### PR TITLE
Additional task data

### DIFF
--- a/backend/alembic/versions/5e3f98d24b75_add_description_and_label_examples_for_.py
+++ b/backend/alembic/versions/5e3f98d24b75_add_description_and_label_examples_for_.py
@@ -1,8 +1,8 @@
 """Add description and label examples for Task
 
-Revision ID: e7b5c96cdde6
+Revision ID: 5e3f98d24b75
 Revises: c075df75ca43
-Create Date: 2019-05-22 22:05:26.235486
+Create Date: 2019-05-24 21:58:51.753199
 
 """
 from alembic import op
@@ -10,16 +10,16 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = 'e7b5c96cdde6'
+revision = '5e3f98d24b75'
 down_revision = 'c075df75ca43'
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
-    op.add_column('Tasks', sa.Column('description', sa.String(length=500), server_default='', nullable=True))
-    op.add_column('Tasks', sa.Column('label_examples', postgresql.ARRAY(sa.String(length=50)), server_default='{}',
-                                     nullable=True))
+    op.add_column('Tasks', sa.Column('description', sa.Text(), server_default='', nullable=True))
+    op.add_column('Tasks', sa.Column('label_examples', postgresql.ARRAY(sa.String(length=256)),
+                                     server_default='{}', nullable=True))
 
 
 def downgrade():

--- a/backend/alembic/versions/e7b5c96cdde6_add_description_and_label_examples_for_.py
+++ b/backend/alembic/versions/e7b5c96cdde6_add_description_and_label_examples_for_.py
@@ -1,0 +1,27 @@
+"""Add description and label examples for Task
+
+Revision ID: e7b5c96cdde6
+Revises: c075df75ca43
+Create Date: 2019-05-22 22:05:26.235486
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'e7b5c96cdde6'
+down_revision = 'c075df75ca43'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('Tasks', sa.Column('description', sa.String(length=500), server_default='', nullable=True))
+    op.add_column('Tasks', sa.Column('label_examples', postgresql.ARRAY(sa.String(length=50)), server_default='{}',
+                                     nullable=True))
+
+
+def downgrade():
+    op.drop_column('Tasks', 'label_examples')
+    op.drop_column('Tasks', 'description')

--- a/backend/medtagger/api/tasks/business.py
+++ b/backend/medtagger/api/tasks/business.py
@@ -36,7 +36,7 @@ def get_task_metadata_for_key(task_key: str) -> TaskMetadata:
     :return: TaskMetadata
     """
     try:
-        return TasksRepository.get_task_metadata_by_key(task_key)
+        return TasksRepository.get_task_metadata_by_key(task_key)._asdict()
     except NoResultFound:
         raise NotFoundException('Did not found task for {} key!'.format(task_key))
 

--- a/backend/medtagger/api/tasks/business.py
+++ b/backend/medtagger/api/tasks/business.py
@@ -1,4 +1,5 @@
 """Module responsible for business logic in all Tasks endpoints."""
+# pylint: disable-msg=too-many-arguments
 from typing import List
 
 from sqlalchemy.orm.exc import NoResultFound

--- a/backend/medtagger/api/tasks/business.py
+++ b/backend/medtagger/api/tasks/business.py
@@ -8,7 +8,6 @@ from medtagger.database.models import Task, LabelTag
 from medtagger.repositories import (
     tasks as TasksRepository,
 )
-from medtagger.types import TaskMetadata
 
 
 def get_tasks() -> List[Task]:
@@ -26,17 +25,6 @@ def get_task_for_key(task_key: str) -> Task:
     """
     try:
         return TasksRepository.get_task_by_key(task_key)
-    except NoResultFound:
-        raise NotFoundException('Did not found task for {} key!'.format(task_key))
-
-
-def get_task_metadata_for_key(task_key: str) -> TaskMetadata:
-    """Fetch Task metadata for given key.
-
-    :return: TaskMetadata
-    """
-    try:
-        return TasksRepository.get_task_metadata_by_key(task_key)._asdict()
     except NoResultFound:
         raise NotFoundException('Did not found task for {} key!'.format(task_key))
 

--- a/backend/medtagger/api/tasks/business.py
+++ b/backend/medtagger/api/tasks/business.py
@@ -1,5 +1,4 @@
 """Module responsible for business logic in all Tasks endpoints."""
-# pylint: disable-msg=too-many-arguments
 from typing import List
 
 from sqlalchemy.orm.exc import NoResultFound
@@ -30,6 +29,7 @@ def get_task_for_key(task_key: str) -> Task:
         raise NotFoundException('Did not found task for {} key!'.format(task_key))
 
 
+# pylint: disable-msg=too-many-arguments
 def create_task(key: str, name: str, image_path: str, datasets_keys: List[str], description: str,
                 label_examples: List[str], tags: List[LabelTag]) -> Task:
     """Create new Task.

--- a/backend/medtagger/api/tasks/business.py
+++ b/backend/medtagger/api/tasks/business.py
@@ -29,14 +29,17 @@ def get_task_for_key(task_key: str) -> Task:
         raise NotFoundException('Did not found task for {} key!'.format(task_key))
 
 
-def create_task(key: str, name: str, image_path: str, datasets_keys: List[str], tags: List[LabelTag]) -> Task:
+def create_task(key: str, name: str, image_path: str, datasets_keys: List[str], description: str,
+                label_examples: List[str], tags: List[LabelTag]) -> Task:
     """Create new Task.
 
     :param key: unique key representing Task
     :param name: name which describes this Task
     :param image_path: path to the image which is located on the frontend
     :param datasets_keys: Keys of Datasets that Task takes Scans from
+    :param description: Description of a given Task
+    :param label_examples: List of paths to examples of labels for given Task
     :param tags: Label Tags that will be created and assigned to Task
     :return: Task object
     """
-    return TasksRepository.add_task(key, name, image_path, datasets_keys, tags)
+    return TasksRepository.add_task(key, name, image_path, datasets_keys, description, label_examples, tags)

--- a/backend/medtagger/api/tasks/business.py
+++ b/backend/medtagger/api/tasks/business.py
@@ -8,6 +8,7 @@ from medtagger.database.models import Task, LabelTag
 from medtagger.repositories import (
     tasks as TasksRepository,
 )
+from medtagger.types import TaskMetadata
 
 
 def get_tasks() -> List[Task]:
@@ -25,6 +26,17 @@ def get_task_for_key(task_key: str) -> Task:
     """
     try:
         return TasksRepository.get_task_by_key(task_key)
+    except NoResultFound:
+        raise NotFoundException('Did not found task for {} key!'.format(task_key))
+
+
+def get_task_metadata_for_key(task_key: str) -> TaskMetadata:
+    """Fetch Task metadata for given key.
+
+    :return: TaskMetadata
+    """
+    try:
+        return TasksRepository.get_task_metadata_by_key(task_key)
     except NoResultFound:
         raise NotFoundException('Did not found task for {} key!'.format(task_key))
 

--- a/backend/medtagger/api/tasks/serializers.py
+++ b/backend/medtagger/api/tasks/serializers.py
@@ -26,6 +26,8 @@ out__task = api.model('Task model', {
     'key': fields.String(),
     'name': fields.String(),
     'image_path': fields.String(),
+    'description': fields.String(),
+    'label_examples': fields.List(fields.String()),
     'tags': fields.List(fields.Nested(out__label_tag), attribute=lambda task: sorted(task.available_tags,
                                                                                      key=lambda tag: tag.name)),
     'datasets_keys': fields.List(fields.String(), attribute=lambda task: [dataset.key for dataset in task.datasets]),
@@ -36,5 +38,7 @@ in__task = api.model('New Task model', {
     'name': fields.String(),
     'image_path': fields.String(),
     'datasets_keys': fields.List(fields.String()),
+    'description': fields.String(),
+    'label_examples': fields.List(fields.String()),
     'tags': fields.List(fields.Nested(in__label_tag), attribute='available_tags'),
 })

--- a/backend/medtagger/api/tasks/serializers.py
+++ b/backend/medtagger/api/tasks/serializers.py
@@ -28,6 +28,9 @@ out__task = api.model('Task model', {
     'image_path': fields.String(),
     'tags': fields.List(fields.Nested(out__label_tag), attribute=lambda task: sorted(task.available_tags,
                                                                                      key=lambda tag: tag.name)),
+    'number_of_available_scans': fields.Integer(),
+    'description': fields.String(required=False),
+    'label_examples': fields.List(fields.String(), required=False),
     'datasets_keys': fields.List(fields.String(), attribute=lambda task: [dataset.key for dataset in task.datasets]),
 })
 
@@ -39,13 +42,4 @@ in__task = api.model('New Task model', {
     'description': fields.String(required=False),
     'label_examples': fields.List(fields.String(), required=False),
     'tags': fields.List(fields.Nested(in__label_tag), attribute='available_tags'),
-})
-
-
-out__task_metadata = api.model('Task metadata model', {
-    'key': fields.String(),
-    'name': fields.String(),
-    'number_of_available_scans': fields.Integer(),
-    'description': fields.String(required=False),
-    'label_examples': fields.List(fields.String(), required=False),
 })

--- a/backend/medtagger/api/tasks/serializers.py
+++ b/backend/medtagger/api/tasks/serializers.py
@@ -26,8 +26,6 @@ out__task = api.model('Task model', {
     'key': fields.String(),
     'name': fields.String(),
     'image_path': fields.String(),
-    'description': fields.String(),
-    'label_examples': fields.List(fields.String()),
     'tags': fields.List(fields.Nested(out__label_tag), attribute=lambda task: sorted(task.available_tags,
                                                                                      key=lambda tag: tag.name)),
     'datasets_keys': fields.List(fields.String(), attribute=lambda task: [dataset.key for dataset in task.datasets]),
@@ -38,7 +36,16 @@ in__task = api.model('New Task model', {
     'name': fields.String(),
     'image_path': fields.String(),
     'datasets_keys': fields.List(fields.String()),
-    'description': fields.String(),
-    'label_examples': fields.List(fields.String()),
+    'description': fields.String(required=False),
+    'label_examples': fields.List(fields.String(), required=False),
     'tags': fields.List(fields.Nested(in__label_tag), attribute='available_tags'),
+})
+
+
+out__task_metadata = api.model('Task metadata model', {
+    'key': fields.String(),
+    'name': fields.String(),
+    'number_of_available_scans': fields.Integer(),
+    'description': fields.String(required=False),
+    'label_examples': fields.List(fields.String(), required=False),
 })

--- a/backend/medtagger/api/tasks/service_rest.py
+++ b/backend/medtagger/api/tasks/service_rest.py
@@ -61,18 +61,3 @@ class Task(Resource):
     def get(task_key: str) -> Any:
         """Return task for given key."""
         return business.get_task_for_key(task_key)
-
-
-@tasks_ns.route('/<string:task_key>/metadata')
-class TaskMetadata(Resource):
-    """Endpoint that manages single task metadata."""
-
-    @staticmethod
-    @login_required
-    @tasks_ns.marshal_with(serializers.out__task_metadata)
-    @tasks_ns.doc(security='token')
-    @tasks_ns.doc(description='Get task metadata for given key.')
-    @tasks_ns.doc(responses={200: 'Success', 404: 'Could not find task'})
-    def get(task_key: str) -> Any:
-        """Return task metadata for given key."""
-        return business.get_task_metadata_for_key(task_key)

--- a/backend/medtagger/api/tasks/service_rest.py
+++ b/backend/medtagger/api/tasks/service_rest.py
@@ -42,8 +42,8 @@ class Tasks(Resource):
         name = payload['name']
         image_path = payload['image_path']
         datasets_keys = payload['datasets_keys']
-        description = payload["description"]
-        label_examples = payload["label_examples"]
+        description = payload.get('description', '')
+        label_examples = payload.get('label_examples', [])
         tags = [LabelTag(tag['key'], tag['name'], tag['tools']) for tag in payload['tags']]
         return business.create_task(key, name, image_path, datasets_keys, description, label_examples, tags), 201
 
@@ -63,16 +63,16 @@ class Task(Resource):
         return business.get_task_for_key(task_key)
 
 
-@tasks_ns.route('/<string:task_key>')
+@tasks_ns.route('/<string:task_key>/metadata')
 class TaskMetadata(Resource):
-    """Return Task Metadata."""
+    """Endpoint that manages single task metadata."""
 
     @staticmethod
     @login_required
-    @tasks_ns.marshal_with(serializers.out__task)
+    @tasks_ns.marshal_with(serializers.out__task_metadata)
     @tasks_ns.doc(security='token')
-    @tasks_ns.doc(description='Get task for given key.')
+    @tasks_ns.doc(description='Get task metadata for given key.')
     @tasks_ns.doc(responses={200: 'Success', 404: 'Could not find task'})
     def get(task_key: str) -> Any:
-        """Return task for given key."""
-        return business.get_task_metadata(task_key)
+        """Return task metadata for given key."""
+        return business.get_task_metadata_for_key(task_key)

--- a/backend/medtagger/api/tasks/service_rest.py
+++ b/backend/medtagger/api/tasks/service_rest.py
@@ -42,8 +42,10 @@ class Tasks(Resource):
         name = payload['name']
         image_path = payload['image_path']
         datasets_keys = payload['datasets_keys']
+        description = payload["description"]
+        label_examples = payload["label_examples"]
         tags = [LabelTag(tag['key'], tag['name'], tag['tools']) for tag in payload['tags']]
-        return business.create_task(key, name, image_path, datasets_keys, tags), 201
+        return business.create_task(key, name, image_path, datasets_keys, description, label_examples, tags), 201
 
 
 @tasks_ns.route('/<string:task_key>')
@@ -59,3 +61,18 @@ class Task(Resource):
     def get(task_key: str) -> Any:
         """Return task for given key."""
         return business.get_task_for_key(task_key)
+
+
+@tasks_ns.route('/<string:task_key>')
+class TaskMetadata(Resource):
+    """Return Task Metadata."""
+
+    @staticmethod
+    @login_required
+    @tasks_ns.marshal_with(serializers.out__task)
+    @tasks_ns.doc(security='token')
+    @tasks_ns.doc(description='Get task for given key.')
+    @tasks_ns.doc(responses={200: 'Success', 404: 'Could not find task'})
+    def get(task_key: str) -> Any:
+        """Return task for given key."""
+        return business.get_task_metadata(task_key)

--- a/backend/medtagger/database/models.py
+++ b/backend/medtagger/database/models.py
@@ -132,7 +132,7 @@ class Task(Base):
     key: str = Column(String(50), nullable=False, unique=True)
     name: str = Column(String(100), nullable=False)
     description: str = Column(Text, nullable=True, server_default='')
-    label_examples: str = Column(ARRAY(String(256)), nullable=True, server_default='{}')
+    label_examples: List[str] = Column(ARRAY(String(256)), nullable=True, server_default='{}')
     image_path: str = Column(String(100), nullable=False)
     disabled: bool = Column(Boolean, nullable=False, server_default='f')
 
@@ -170,7 +170,7 @@ class Task(Base):
         """Return a number of available Scans for this Task."""
         datasets_ids = [dataset.id for dataset in self.datasets]
         number_of_scans = Scan.query.filter(and_(
-            Scan.dataset_id.in_(datasets_ids),
+            Scan.dataset_id.in_(datasets_ids),  # type: ignore  # "int" has no attribute "in_"
             Scan.status == ScanStatus.AVAILABLE,
         )).count()
         return number_of_scans

--- a/backend/medtagger/database/models.py
+++ b/backend/medtagger/database/models.py
@@ -167,7 +167,7 @@ class Task(Base):
 
     @property
     def number_of_available_scans(self) -> int:
-        """Returns a number of available Scans for this Task."""
+        """Return a number of available Scans for this Task."""
         datasets_ids = [dataset.id for dataset in self.datasets]
         number_of_scans = Scan.query.filter(and_(
             Scan.dataset_id.in_(datasets_ids),

--- a/backend/medtagger/database/models.py
+++ b/backend/medtagger/database/models.py
@@ -170,7 +170,8 @@ class Task(Base):
         """Returns a number of available Scans for this Task."""
         datasets_ids = [dataset.id for dataset in self.datasets]
         number_of_scans = Scan.query.filter(and_(
-            Scan.dataset_id.in_(datasets_ids)
+            Scan.dataset_id.in_(datasets_ids),
+            Scan.status == ScanStatus.AVAILABLE,
         )).count()
         return number_of_scans
 

--- a/backend/medtagger/database/models.py
+++ b/backend/medtagger/database/models.py
@@ -4,7 +4,7 @@ import uuid
 from typing import List, Dict, cast, Optional, Any
 
 from sqlalchemy import Column, Integer, Float, String, ForeignKey, Boolean, Enum, Table, and_, event, false
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, ARRAY
 from sqlalchemy.engine import Connection
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.mapper import Mapper
@@ -131,6 +131,8 @@ class Task(Base):
     id: TaskID = Column(Integer, autoincrement=True, primary_key=True)
     key: str = Column(String(50), nullable=False, unique=True)
     name: str = Column(String(100), nullable=False)
+    description: str = Column(String(500), nullable=True)
+    label_examples: str = Column(ARRAY(String(50)), nullable=True)
     image_path: str = Column(String(100), nullable=False)
     disabled: bool = Column(Boolean, nullable=False, server_default='f')
 
@@ -139,15 +141,17 @@ class Task(Base):
 
     _tags: List['LabelTag'] = relationship("LabelTag", back_populates="task")
 
-    def __init__(self, key: str, name: str, image_path: str) -> None:
+    def __init__(self, key: str, name: str, image_path: str, description: str) -> None:
         """Initialize Task.
 
         :param key: unique key representing Task
         :param name: name which describes this Task
         :param image_path: path to the image which is located on the frontend
+        :param description: Description for a given Task
         """
         self.key = key
         self.name = name
+        self.description = description
         self.image_path = image_path
 
     def __repr__(self) -> str:

--- a/backend/medtagger/database/models.py
+++ b/backend/medtagger/database/models.py
@@ -168,12 +168,11 @@ class Task(Base):
     @property
     def number_of_available_scans(self) -> int:
         """Returns a number of available Scans for this Task."""
-
-        scans = Scan.query.filter(and_(
-            Slice.dataset == self.id,
-            Slice.orientation == SliceOrientation.Z,
-            Slice.height.isnot(None),  # type: ignore  # "int" has no attribute "isnot"
-        )).first()
+        datasets_ids = [dataset.id for dataset in self.datasets]
+        number_of_scans = Scan.query.filter(and_(
+            Scan.dataset_id.in_(datasets_ids)
+        )).count()
+        return number_of_scans
 
 
 class Scan(Base):

--- a/backend/medtagger/repositories/tasks.py
+++ b/backend/medtagger/repositories/tasks.py
@@ -86,8 +86,8 @@ def unassign_label_tag(tag: LabelTag, task_key: str) -> None:
         session.add(task)
 
 
-def update(task_key: str, description: str = None, label_examples: List[str] = None, name: str = None,
-           image_path: str = None, datasets_keys: List[str] = None) -> Task:
+def update(task_key: str, name: str = None, image_path: str = None, datasets_keys: List[str] = None,
+           description: str = None, label_examples: List[str] = None) -> Task:
     """Update Datasets where this Task will be available.
 
     :param task_key: key that will identify such Task

--- a/backend/medtagger/repositories/tasks.py
+++ b/backend/medtagger/repositories/tasks.py
@@ -1,5 +1,4 @@
 """Module responsible for definition of TaskRepository."""
-# pylint: disable-msg=too-many-arguments
 from typing import List
 
 from medtagger.database import db_connection_session, db_transaction_session
@@ -26,6 +25,7 @@ def get_task_by_key(key: str) -> Task:
     return task
 
 
+# pylint: disable-msg=too-many-arguments
 def add_task(key: str, name: str, image_path: str, datasets_keys: List[str], description: str,
              label_examples: List[str], tags: List[LabelTag]) -> Task:
     """Add new Task to the database.
@@ -74,6 +74,7 @@ def unassign_label_tag(tag: LabelTag, task_key: str) -> None:
         session.add(task)
 
 
+# pylint: disable-msg=too-many-arguments
 def update(task_key: str, name: str = None, image_path: str = None, datasets_keys: List[str] = None,
            description: str = None, label_examples: List[str] = None) -> Task:
     """Update Datasets where this Task will be available.

--- a/backend/medtagger/repositories/tasks.py
+++ b/backend/medtagger/repositories/tasks.py
@@ -1,4 +1,5 @@
 """Module responsible for definition of TaskRepository."""
+# pylint: disable-msg=too-many-arguments
 from typing import List
 
 from medtagger.database import db_connection_session, db_transaction_session

--- a/backend/medtagger/repositories/tasks.py
+++ b/backend/medtagger/repositories/tasks.py
@@ -25,20 +25,24 @@ def get_task_by_key(key: str) -> Task:
     return task
 
 
-def add_task(key: str, name: str, image_path: str, datasets_keys: List[str], tags: List[LabelTag]) -> Task:
+def add_task(key: str, name: str, image_path: str, datasets_keys: List[str], description: str,
+             label_examples: List[str], tags: List[LabelTag]) -> Task:
     """Add new Task to the database.
 
     :param key: key that will identify such Task
     :param name: name that will be used in the Use Interface for such Task
     :param image_path: path to the image that represents such Task (used in User Interface)
     :param datasets_keys: Keys of Datasets that Task takes Scans from
+    :param description: Description of a given Task
+    :param label_examples: List of paths to examples of labels for given Task
     :param tags: Label Tags that will be created and assigned to Task
     :return: Task object
     """
     with db_transaction_session() as session:
-        task = Task(key, name, image_path)
+        task = Task(key, name, image_path, description)
         datasets = Dataset.query.filter(Dataset.key.in_(datasets_keys)).all()  # type: ignore
         task.datasets = datasets
+        task.label_examples = label_examples
         task.available_tags = tags
         session.add(task)
     return task

--- a/backend/medtagger/repositories/tasks.py
+++ b/backend/medtagger/repositories/tasks.py
@@ -25,9 +25,8 @@ def get_task_by_key(key: str) -> Task:
     return task
 
 
-# pylint: disable-msg=too-many-arguments
-def add_task(key: str, name: str, image_path: str, datasets_keys: List[str], description: str,
-             label_examples: List[str], tags: List[LabelTag]) -> Task:
+def add_task(key: str, name: str, image_path: str, datasets_keys: List[str], # pylint: disable-msg=too-many-arguments
+             description: str, label_examples: List[str], tags: List[LabelTag]) -> Task:
     """Add new Task to the database.
 
     :param key: key that will identify such Task
@@ -74,9 +73,8 @@ def unassign_label_tag(tag: LabelTag, task_key: str) -> None:
         session.add(task)
 
 
-# pylint: disable-msg=too-many-arguments
-def update(task_key: str, name: str = None, image_path: str = None, datasets_keys: List[str] = None,
-           description: str = None, label_examples: List[str] = None) -> Task:
+def update(task_key: str, name: str = None, image_path: str = None,  # pylint: disable-msg=too-many-arguments
+           datasets_keys: List[str] = None, description: str = None, label_examples: List[str] = None) -> Task:
     """Update Datasets where this Task will be available.
 
     :param task_key: key that will identify such Task

--- a/backend/medtagger/repositories/tasks.py
+++ b/backend/medtagger/repositories/tasks.py
@@ -4,7 +4,6 @@ from typing import List
 from medtagger.database import db_connection_session, db_transaction_session
 from medtagger.database.models import Task, LabelTag, Dataset
 from medtagger.exceptions import InternalErrorException
-from medtagger.types import TaskMetadata
 
 
 def get_all_tasks(include_disabled: bool = False) -> List[Task]:
@@ -24,18 +23,6 @@ def get_task_by_key(key: str) -> Task:
     with db_connection_session() as session:
         task = session.query(Task).filter(Task.key == key).first()
     return task
-
-
-def get_task_metadata_by_key(key: str) -> TaskMetadata:
-    """Fetch Task metadata database.
-
-    :param key: key for a Task
-    :return: Task metadata object
-    """
-    with db_connection_session() as session:
-        task = session.query(Task).filter(Task.key == key).first()
-    return TaskMetadata(key=task.key, name=task.name, description=task.description, label_examples=task.label_examples,
-                        number_of_available_scans=task.number_of_available_scans)
 
 
 def add_task(key: str, name: str, image_path: str, datasets_keys: List[str], description: str,

--- a/backend/medtagger/repositories/tasks.py
+++ b/backend/medtagger/repositories/tasks.py
@@ -34,8 +34,7 @@ def get_task_metadata_by_key(key: str) -> TaskMetadata:
     """
     with db_connection_session() as session:
         task = session.query(Task).filter(Task.key == key).first()
-    return TaskMetadata(task_id=task.id, task_name=task.name, description=task.description,
-                        label_examples=task.label_examples,
+    return TaskMetadata(key=task.key, name=task.name, description=task.description, label_examples=task.label_examples,
                         number_of_available_scans=task.number_of_available_scans)
 
 
@@ -53,7 +52,7 @@ def add_task(key: str, name: str, image_path: str, datasets_keys: List[str], des
     :return: Task object
     """
     with db_transaction_session() as session:
-        task = Task(key, name, image_path, description)
+        task = Task(key, name, image_path)
         datasets = Dataset.query.filter(Dataset.key.in_(datasets_keys)).all()  # type: ignore
         task.datasets = datasets
         task.label_examples = label_examples

--- a/backend/medtagger/types.py
+++ b/backend/medtagger/types.py
@@ -26,6 +26,3 @@ SurveyElementID = NewType('SurveyElementID', int)
 SurveyElementKey = NewType('SurveyElementKey', str)
 ActionResponseID = NewType('ActionResponseID', int)
 SurveyResponseID = NewType('SurveyResponseID', ActionResponseID)
-
-TaskMetadata = NamedTuple('TaskMetadata', [('key', str), ('name', str), ('description', str),
-                                           ('label_examples', List[str]), ('number_of_available_scans', int)])

--- a/backend/medtagger/types.py
+++ b/backend/medtagger/types.py
@@ -1,5 +1,5 @@
 """Module containing all custom types."""
-from typing import NewType, NamedTuple, List
+from typing import NewType, NamedTuple
 
 UserID = NewType('UserID', int)
 ScanID = NewType('ScanID', str)

--- a/backend/medtagger/types.py
+++ b/backend/medtagger/types.py
@@ -1,6 +1,5 @@
 """Module containing all custom types."""
-from typing import NewType, NamedTuple
-
+from typing import NewType, NamedTuple, List
 
 UserID = NewType('UserID', int)
 ScanID = NewType('ScanID', str)
@@ -27,3 +26,6 @@ SurveyElementID = NewType('SurveyElementID', int)
 SurveyElementKey = NewType('SurveyElementKey', str)
 ActionResponseID = NewType('ActionResponseID', int)
 SurveyResponseID = NewType('SurveyResponseID', ActionResponseID)
+
+TaskMetadata = NamedTuple('TaskMetadata', [('task_id', TaskID), ('task_name', str), ('description', str),
+                                           ('label_examples', List[str]), ('number_of_available_scans', int)])

--- a/backend/medtagger/types.py
+++ b/backend/medtagger/types.py
@@ -27,5 +27,5 @@ SurveyElementKey = NewType('SurveyElementKey', str)
 ActionResponseID = NewType('ActionResponseID', int)
 SurveyResponseID = NewType('SurveyResponseID', ActionResponseID)
 
-TaskMetadata = NamedTuple('TaskMetadata', [('task_id', TaskID), ('task_name', str), ('description', str),
+TaskMetadata = NamedTuple('TaskMetadata', [('key', str), ('name', str), ('description', str),
                                            ('label_examples', List[str]), ('number_of_available_scans', int)])

--- a/backend/scripts/sync_configuration.py
+++ b/backend/scripts/sync_configuration.py
@@ -79,7 +79,7 @@ def _sync_tasks(configuration: Dict) -> None:
         name: Kidneys segmentation
         image_path: assets/icon/kidneys_dataset_icon.svg
         description: Task description
-        label_examples: [assets/example_1, assets/example_2]
+        label_examples: ['assets/example_1', 'assets/example_2']
         tags:
           - key: LEFT_KIDNEY
             name: Left Kidney
@@ -117,7 +117,8 @@ def _sync_tasks(configuration: Dict) -> None:
         _sync_label_tags_in_task(configuration, task_key)
         task = next(task for task in tasks if task['key'] == task_key)
         datasets_keys = [dataset['key'] for dataset in datasets if task['key'] in dataset['tasks']]
-        TasksRepository.update(task_key, task['name'], task['image_path'], datasets_keys)
+        TasksRepository.update(task_key, task['name'], task['image_path'], datasets_keys, task['description'],
+                               task['label_examples'])
         logger.info('Task enabled: %s', task_key)
 
     # Disable all Tasks that exists in the DB but are missing in configuration file

--- a/backend/scripts/sync_configuration.py
+++ b/backend/scripts/sync_configuration.py
@@ -106,8 +106,8 @@ def _sync_tasks(configuration: Dict) -> None:
     for task_key in tasks_to_add:
         task = next(task for task in tasks if task['key'] == task_key)
         datasets_keys = [dataset['key'] for dataset in datasets if task['key'] in dataset['tasks']]
-        TasksRepository.add_task(task['key'], task['name'], task['image_path'], datasets_keys, task["description"],
-                                 task["label_examples"], [])
+        TasksRepository.add_task(task['key'], task['name'], task['image_path'], datasets_keys,
+                                 task.get('description', ''), task.get("label_examples", []), [])
         _sync_label_tags_in_task(configuration, task_key)
         logger.info('New Task added: %s', task['key'])
 

--- a/backend/scripts/sync_configuration.py
+++ b/backend/scripts/sync_configuration.py
@@ -78,6 +78,8 @@ def _sync_tasks(configuration: Dict) -> None:
       - key: KIDNEYS_SEGMENTATION
         name: Kidneys segmentation
         image_path: assets/icon/kidneys_dataset_icon.svg
+        description: Task description
+        label_examples: [assets/example_1, assets/example_2]
         tags:
           - key: LEFT_KIDNEY
             name: Left Kidney
@@ -104,7 +106,8 @@ def _sync_tasks(configuration: Dict) -> None:
     for task_key in tasks_to_add:
         task = next(task for task in tasks if task['key'] == task_key)
         datasets_keys = [dataset['key'] for dataset in datasets if task['key'] in dataset['tasks']]
-        TasksRepository.add_task(task['key'], task['name'], task['image_path'], datasets_keys, [])
+        TasksRepository.add_task(task['key'], task['name'], task['image_path'], datasets_keys, task["description"],
+                                 task["label_examples"], [])
         _sync_label_tags_in_task(configuration, task_key)
         logger.info('New Task added: %s', task['key'])
 

--- a/backend/tests/functional_tests/helpers.py
+++ b/backend/tests/functional_tests/helpers.py
@@ -30,7 +30,7 @@ def create_tag_and_assign_to_task(key: str, name: str, task_key: str, tools: Lis
 def prepare_scan_and_tag_for_labeling() -> Tuple[models.Scan, models.LabelTag]:
     """Create needed Scan and Label Tag for labeling purpose."""
     dataset = DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     label_tag = LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [definitions.LabelTool.POINT], task.id)
     scan = ScansRepository.add_new_scan(dataset, number_of_slices=3)
     for _ in range(3):

--- a/backend/tests/functional_tests/scripts/test_sync_configuration.py
+++ b/backend/tests/functional_tests/scripts/test_sync_configuration.py
@@ -54,7 +54,7 @@ def test_sync_with_empty_database(prepare_environment: Any) -> None:
     assert kidneys_segmentation.name == 'Kidneys segmentation'
     assert kidneys_segmentation.image_path == 'assets/icon/kidneys_dataset_icon.svg'
     assert kidneys_segmentation.description == 'This is a test task'
-    assert len(kidneys_segmentation.label_examples) == 2
+    assert kidneys_segmentation.label_examples == ['assets/example_1', 'assets/example_2']
     assert not kidneys_segmentation.disabled
     assert len(kidneys_segmentation.available_tags) == 2
     assert {tag.key for tag in kidneys_segmentation.available_tags} == {'LEFT_KIDNEY', 'RIGHT_KIDNEY'}
@@ -142,7 +142,7 @@ def test_sync_with_updated_names(prepare_environment: Any) -> None:
     assert kidneys_segmentation.name == 'New Kidneys segmentation'
     assert kidneys_segmentation.image_path == 'new_assets/icon/kidneys_dataset_icon.svg'
     assert kidneys_segmentation.description == 'This is a test task'
-    assert len(kidneys_segmentation.label_examples) == 2
+    assert kidneys_segmentation.label_examples == ['assets/example_1', 'assets/example_2']
     assert not kidneys_segmentation.disabled
     assert len(kidneys_segmentation.available_tags) == 2
     assert {tag.key for tag in kidneys_segmentation.available_tags} == {'LEFT_KIDNEY', 'RIGHT_KIDNEY'}
@@ -398,7 +398,7 @@ def test_sync_with_changed_task_in_dataset(mocker: Any, prepare_environment: Any
     assert kidneys_segmentation.name == 'New Kidneys segmentation'
     assert kidneys_segmentation.image_path == 'assets/icon/kidneys_dataset_icon.svg'
     assert kidneys_segmentation.description == 'This is a test task'
-    assert len(kidneys_segmentation.label_examples) == 2
+    assert kidneys_segmentation.label_examples == ['assets/example_1', 'assets/example_2']
     assert not kidneys_segmentation.disabled
     assert len(kidneys_segmentation.available_tags) == 1
     assert {tag.key for tag in kidneys_segmentation.available_tags} == {'NEW_LEFT_KIDNEY'}
@@ -479,6 +479,8 @@ def test_sync_with_changed_dataset_and_reused_task(prepare_environment: Any) -> 
     script.sync_configuration(configuration)
 
     # Check if description was synchronized properly
+    datasets = DatasetsRepository.get_all_datasets(include_disabled=True)
+    assert len(datasets) == 1
     kidneys = DatasetsRepository.get_dataset_by_key('KIDNEYS')
     assert kidneys.name == 'Kidneys'
     assert not kidneys.disabled

--- a/backend/tests/functional_tests/scripts/test_sync_configuration.py
+++ b/backend/tests/functional_tests/scripts/test_sync_configuration.py
@@ -24,8 +24,8 @@ def test_sync_with_empty_database(prepare_environment: Any) -> None:
           - key: KIDNEYS_SEGMENTATION
             name: Kidneys segmentation
             image_path: assets/icon/kidneys_dataset_icon.svg
-            description: ''
-            label_examples: []
+            description: This is a test task
+            label_examples: ['assets/example_1', 'assets/example_2']
             tags:
               - key: LEFT_KIDNEY
                 name: Left Kidney
@@ -53,6 +53,8 @@ def test_sync_with_empty_database(prepare_environment: Any) -> None:
     kidneys_segmentation = TasksRepository.get_task_by_key('KIDNEYS_SEGMENTATION')
     assert kidneys_segmentation.name == 'Kidneys segmentation'
     assert kidneys_segmentation.image_path == 'assets/icon/kidneys_dataset_icon.svg'
+    assert kidneys_segmentation.description == 'This is a test task'
+    assert len(kidneys_segmentation.label_examples) == 2
     assert not kidneys_segmentation.disabled
     assert len(kidneys_segmentation.available_tags) == 2
     assert {tag.key for tag in kidneys_segmentation.available_tags} == {'LEFT_KIDNEY', 'RIGHT_KIDNEY'}
@@ -83,8 +85,8 @@ def test_sync_with_updated_names(prepare_environment: Any) -> None:
           - key: KIDNEYS_SEGMENTATION
             name: Kidneys segmentation
             image_path: assets/icon/kidneys_dataset_icon.svg
-            description: ''
-            label_examples: []
+            description: This is a test task
+            label_examples: ['assets/example_1', 'assets/example_2']
             tags:
               - key: LEFT_KIDNEY
                 name: Left Kidney
@@ -110,6 +112,8 @@ def test_sync_with_updated_names(prepare_environment: Any) -> None:
           - key: KIDNEYS_SEGMENTATION
             name: New Kidneys segmentation
             image_path: new_assets/icon/kidneys_dataset_icon.svg
+            description: This is a test task
+            label_examples: ['assets/example_1', 'assets/example_2']
             tags:
               - key: LEFT_KIDNEY
                 name: New Left Kidney
@@ -137,6 +141,8 @@ def test_sync_with_updated_names(prepare_environment: Any) -> None:
     kidneys_segmentation = TasksRepository.get_task_by_key('KIDNEYS_SEGMENTATION')
     assert kidneys_segmentation.name == 'New Kidneys segmentation'
     assert kidneys_segmentation.image_path == 'new_assets/icon/kidneys_dataset_icon.svg'
+    assert kidneys_segmentation.description == 'This is a test task'
+    assert len(kidneys_segmentation.label_examples) == 2
     assert not kidneys_segmentation.disabled
     assert len(kidneys_segmentation.available_tags) == 2
     assert {tag.key for tag in kidneys_segmentation.available_tags} == {'LEFT_KIDNEY', 'RIGHT_KIDNEY'}
@@ -167,8 +173,8 @@ def test_sync_with_changed_tools_in_tag(prepare_environment: Any) -> None:
           - key: KIDNEYS_SEGMENTATION
             name: Kidneys segmentation
             image_path: assets/icon/kidneys_dataset_icon.svg
-            description: ''
-            label_examples: []
+            description: This is a test task
+            label_examples: ['assets/example_1', 'assets/example_2']
             tags:
               - key: LEFT_KIDNEY
                 name: Left Kidney
@@ -198,8 +204,8 @@ def test_sync_with_changed_tools_in_tag(prepare_environment: Any) -> None:
           - key: KIDNEYS_SEGMENTATION
             name: Kidneys segmentation
             image_path: assets/icon/kidneys_dataset_icon.svg
-            description: ''
-            label_examples: ''
+            description: This is a test task
+            label_examples: ['assets/example_1', 'assets/example_2']
             tags:
               - key: LEFT_KIDNEY
                 name: Left Kidney
@@ -231,8 +237,8 @@ def test_sync_with_changed_tags_in_task(prepare_environment: Any) -> None:
           - key: KIDNEYS_SEGMENTATION
             name: Kidneys segmentation
             image_path: assets/icon/kidneys_dataset_icon.svg
-            description: ''
-            label_examples: []
+            description: This is a test task
+            label_examples: ['assets/example_1', 'assets/example_2']
             tags:
               - key: LEFT_KIDNEY
                 name: Left Kidney
@@ -262,8 +268,8 @@ def test_sync_with_changed_tags_in_task(prepare_environment: Any) -> None:
           - key: KIDNEYS_SEGMENTATION
             name: Kidneys segmentation
             image_path: assets/icon/kidneys_dataset_icon.svg
-            description: ''
-            label_examples: []
+            description: This is a test task
+            label_examples: ['assets/example_1', 'assets/example_2']
             tags:
               - key: RIGHT_KIDNEY
                 name: Right Kidney
@@ -298,8 +304,8 @@ def test_sync_with_changed_task_in_dataset(mocker: Any, prepare_environment: Any
           - key: KIDNEYS_SEGMENTATION
             name: Kidneys segmentation
             image_path: assets/icon/kidneys_dataset_icon.svg
-            description: ''
-            label_examples: []
+            description: This is a test task
+            label_examples: ['assets/example_1', 'assets/example_2']
             tags:
               - key: LEFT_KIDNEY
                 name: Left Kidney
@@ -332,8 +338,8 @@ def test_sync_with_changed_task_in_dataset(mocker: Any, prepare_environment: Any
           - key: FIND_NODULES
             name: Find nodules
             image_path: assets/icon/kidneys_dataset_icon.svg
-            description: ''
-            label_examples: []
+            description: This is a test task
+            label_examples: ['assets/example_1', 'assets/example_2']
             tags:
               - key: NODULE
                 name: Nodule
@@ -368,8 +374,8 @@ def test_sync_with_changed_task_in_dataset(mocker: Any, prepare_environment: Any
           - key: KIDNEYS_SEGMENTATION
             name: New Kidneys segmentation
             image_path: assets/icon/kidneys_dataset_icon.svg
-            description: ''
-            label_examples: []
+            description: This is a test task
+            label_examples: ['assets/example_1', 'assets/example_2']
             tags:
               - key: NEW_LEFT_KIDNEY
                 name: New Left Kidney
@@ -391,6 +397,8 @@ def test_sync_with_changed_task_in_dataset(mocker: Any, prepare_environment: Any
     kidneys_segmentation = TasksRepository.get_task_by_key('KIDNEYS_SEGMENTATION')
     assert kidneys_segmentation.name == 'New Kidneys segmentation'
     assert kidneys_segmentation.image_path == 'assets/icon/kidneys_dataset_icon.svg'
+    assert kidneys_segmentation.description == 'This is a test task'
+    assert len(kidneys_segmentation.label_examples) == 2
     assert not kidneys_segmentation.disabled
     assert len(kidneys_segmentation.available_tags) == 1
     assert {tag.key for tag in kidneys_segmentation.available_tags} == {'NEW_LEFT_KIDNEY'}
@@ -418,8 +426,8 @@ def test_sync_with_changed_task_in_dataset(mocker: Any, prepare_environment: Any
           - key: KIDNEYS_SEGMENTATION
             name: Kidneys segmentation
             image_path: assets/icon/kidneys_dataset_icon.svg
-            description: ''
-            label_examples: []
+            description: This is a test task
+            label_examples: ['assets/example_1', 'assets/example_2']
             tags:
               - key: LEFT_KIDNEY
                 name: Left Kidney
@@ -460,8 +468,8 @@ def test_sync_with_changed_dataset_and_reused_task(prepare_environment: Any) -> 
           - key: FIND_NODULES
             name: Find nodules
             image_path: assets/icon/kidneys_dataset_icon.svg
-            description: ''
-            label_examples: []
+            description: This is a test task
+            label_examples: ['assets/example_1', 'assets/example_2']
             tags:
               - key: NODULE
                 name: Nodule
@@ -470,9 +478,7 @@ def test_sync_with_changed_dataset_and_reused_task(prepare_environment: Any) -> 
     """)
     script.sync_configuration(configuration)
 
-    # Check if Datasets were synchronized properly
-    datasets = DatasetsRepository.get_all_datasets(include_disabled=True)
-    assert len(datasets) == 1
+    # Check if description was synchronized properly
     kidneys = DatasetsRepository.get_dataset_by_key('KIDNEYS')
     assert kidneys.name == 'Kidneys'
     assert not kidneys.disabled
@@ -490,8 +496,8 @@ def test_sync_with_changed_dataset_and_reused_task(prepare_environment: Any) -> 
           - key: FIND_NODULES
             name: Find nodules
             image_path: assets/icon/kidneys_dataset_icon.svg
-            description: ''
-            label_examples: []
+            description: This is a test task with updated description
+            label_examples: ['assets/example_1', 'assets/example_2']
             tags:
               - key: NODULE
                 name: Nodule
@@ -511,3 +517,139 @@ def test_sync_with_changed_dataset_and_reused_task(prepare_environment: Any) -> 
     assert lungs.name == 'Lungs'
     assert not lungs.disabled
     assert {task.key for task in lungs.tasks} == {'FIND_NODULES'}
+
+
+def test_sync_with_changed_description(prepare_environment: Any) -> None:
+    """Test for configuration synchronization with updated description."""
+    configuration = yaml.load("""
+            datasets:
+              - key: KIDNEYS
+                name: Kidneys
+                tasks:
+                  - KIDNEYS_SEGMENTATION
+
+            tasks:
+              - key: KIDNEYS_SEGMENTATION
+                name: Kidneys segmentation
+                image_path: assets/icon/kidneys_dataset_icon.svg
+                description: This is a test task
+                label_examples: ['assets/example_1', 'assets/example_2']
+                tags:
+                  - key: LEFT_KIDNEY
+                    name: Left Kidney
+                    tools:
+                      - CHAIN
+                      - BRUSH
+                  - key: RIGHT_KIDNEY
+                    name: Right Kidney
+                    tools:
+                      - CHAIN
+        """)
+    script.sync_configuration(configuration)
+
+    # Check if Tasks were synchronized properly
+    tasks = TasksRepository.get_all_tasks(include_disabled=True)
+    assert len(tasks) == 1
+    kidneys_segmentation = TasksRepository.get_task_by_key('KIDNEYS_SEGMENTATION')
+    assert kidneys_segmentation.description == 'This is a test task'
+
+    # Update configuration
+    configuration = yaml.load("""
+            datasets:
+              - key: KIDNEYS
+                name: New Kidneys
+                tasks:
+                  - KIDNEYS_SEGMENTATION
+
+            tasks:
+              - key: KIDNEYS_SEGMENTATION
+                name: New Kidneys segmentation
+                image_path: new_assets/icon/kidneys_dataset_icon.svg
+                description: This is a test task with updated description
+                label_examples: ['assets/example_1', 'assets/example_2']
+                tags:
+                  - key: LEFT_KIDNEY
+                    name: New Left Kidney
+                    tools:
+                      - CHAIN
+                      - BRUSH
+                  - key: RIGHT_KIDNEY
+                    name: New Right Kidney
+                    tools:
+                      - CHAIN
+        """)
+    script.sync_configuration(configuration)
+
+    # Check if Tasks were synchronized properly
+    tasks = TasksRepository.get_all_tasks(include_disabled=True)
+    assert len(tasks) == 1
+    kidneys_segmentation = TasksRepository.get_task_by_key('KIDNEYS_SEGMENTATION')
+    assert kidneys_segmentation.description == 'This is a test task with updated description'
+
+
+def test_sync_with_changed_label_examples(prepare_environment: Any) -> None:
+    """Test for configuration synchronization with updated label examples."""
+    configuration = yaml.load("""
+            datasets:
+              - key: KIDNEYS
+                name: Kidneys
+                tasks:
+                  - KIDNEYS_SEGMENTATION
+
+            tasks:
+              - key: KIDNEYS_SEGMENTATION
+                name: Kidneys segmentation
+                image_path: assets/icon/kidneys_dataset_icon.svg
+                description: This is a test task
+                label_examples: ['assets/example_1', 'assets/example_2']
+                tags:
+                  - key: LEFT_KIDNEY
+                    name: Left Kidney
+                    tools:
+                      - CHAIN
+                      - BRUSH
+                  - key: RIGHT_KIDNEY
+                    name: Right Kidney
+                    tools:
+                      - CHAIN
+        """)
+    script.sync_configuration(configuration)
+
+    # Check if Tasks were synchronized properly
+    tasks = TasksRepository.get_all_tasks(include_disabled=True)
+    assert len(tasks) == 1
+    kidneys_segmentation = TasksRepository.get_task_by_key('KIDNEYS_SEGMENTATION')
+    assert kidneys_segmentation.label_examples == ['assets/example_1', 'assets/example_2']
+
+    # Update configuration
+    configuration = yaml.load("""
+            datasets:
+              - key: KIDNEYS
+                name: New Kidneys
+                tasks:
+                  - KIDNEYS_SEGMENTATION
+
+            tasks:
+              - key: KIDNEYS_SEGMENTATION
+                name: New Kidneys segmentation
+                image_path: new_assets/icon/kidneys_dataset_icon.svg
+                description: This is a test task
+                label_examples: ['new_assets/example_1']
+                tags:
+                  - key: LEFT_KIDNEY
+                    name: New Left Kidney
+                    tools:
+                      - CHAIN
+                      - BRUSH
+                  - key: RIGHT_KIDNEY
+                    name: New Right Kidney
+                    tools:
+                      - CHAIN
+        """)
+    script.sync_configuration(configuration)
+
+    # Check if Tasks were synchronized properly
+    tasks = TasksRepository.get_all_tasks(include_disabled=True)
+    assert len(tasks) == 1
+    kidneys_segmentation = TasksRepository.get_task_by_key('KIDNEYS_SEGMENTATION')
+    assert kidneys_segmentation.label_examples == ['new_assets/example_1']

--- a/backend/tests/functional_tests/scripts/test_sync_configuration.py
+++ b/backend/tests/functional_tests/scripts/test_sync_configuration.py
@@ -24,6 +24,8 @@ def test_sync_with_empty_database(prepare_environment: Any) -> None:
           - key: KIDNEYS_SEGMENTATION
             name: Kidneys segmentation
             image_path: assets/icon/kidneys_dataset_icon.svg
+            description: ''
+            label_examples: []
             tags:
               - key: LEFT_KIDNEY
                 name: Left Kidney
@@ -81,6 +83,8 @@ def test_sync_with_updated_names(prepare_environment: Any) -> None:
           - key: KIDNEYS_SEGMENTATION
             name: Kidneys segmentation
             image_path: assets/icon/kidneys_dataset_icon.svg
+            description: ''
+            label_examples: []
             tags:
               - key: LEFT_KIDNEY
                 name: Left Kidney
@@ -163,6 +167,8 @@ def test_sync_with_changed_tools_in_tag(prepare_environment: Any) -> None:
           - key: KIDNEYS_SEGMENTATION
             name: Kidneys segmentation
             image_path: assets/icon/kidneys_dataset_icon.svg
+            description: ''
+            label_examples: []
             tags:
               - key: LEFT_KIDNEY
                 name: Left Kidney
@@ -192,6 +198,8 @@ def test_sync_with_changed_tools_in_tag(prepare_environment: Any) -> None:
           - key: KIDNEYS_SEGMENTATION
             name: Kidneys segmentation
             image_path: assets/icon/kidneys_dataset_icon.svg
+            description: ''
+            label_examples: ''
             tags:
               - key: LEFT_KIDNEY
                 name: Left Kidney
@@ -223,6 +231,8 @@ def test_sync_with_changed_tags_in_task(prepare_environment: Any) -> None:
           - key: KIDNEYS_SEGMENTATION
             name: Kidneys segmentation
             image_path: assets/icon/kidneys_dataset_icon.svg
+            description: ''
+            label_examples: []
             tags:
               - key: LEFT_KIDNEY
                 name: Left Kidney
@@ -252,6 +262,8 @@ def test_sync_with_changed_tags_in_task(prepare_environment: Any) -> None:
           - key: KIDNEYS_SEGMENTATION
             name: Kidneys segmentation
             image_path: assets/icon/kidneys_dataset_icon.svg
+            description: ''
+            label_examples: []
             tags:
               - key: RIGHT_KIDNEY
                 name: Right Kidney
@@ -286,6 +298,8 @@ def test_sync_with_changed_task_in_dataset(mocker: Any, prepare_environment: Any
           - key: KIDNEYS_SEGMENTATION
             name: Kidneys segmentation
             image_path: assets/icon/kidneys_dataset_icon.svg
+            description: ''
+            label_examples: []
             tags:
               - key: LEFT_KIDNEY
                 name: Left Kidney
@@ -318,6 +332,8 @@ def test_sync_with_changed_task_in_dataset(mocker: Any, prepare_environment: Any
           - key: FIND_NODULES
             name: Find nodules
             image_path: assets/icon/kidneys_dataset_icon.svg
+            description: ''
+            label_examples: []
             tags:
               - key: NODULE
                 name: Nodule
@@ -352,6 +368,8 @@ def test_sync_with_changed_task_in_dataset(mocker: Any, prepare_environment: Any
           - key: KIDNEYS_SEGMENTATION
             name: New Kidneys segmentation
             image_path: assets/icon/kidneys_dataset_icon.svg
+            description: ''
+            label_examples: []
             tags:
               - key: NEW_LEFT_KIDNEY
                 name: New Left Kidney
@@ -400,6 +418,8 @@ def test_sync_with_changed_task_in_dataset(mocker: Any, prepare_environment: Any
           - key: KIDNEYS_SEGMENTATION
             name: Kidneys segmentation
             image_path: assets/icon/kidneys_dataset_icon.svg
+            description: ''
+            label_examples: []
             tags:
               - key: LEFT_KIDNEY
                 name: Left Kidney
@@ -440,6 +460,8 @@ def test_sync_with_changed_dataset_and_reused_task(prepare_environment: Any) -> 
           - key: FIND_NODULES
             name: Find nodules
             image_path: assets/icon/kidneys_dataset_icon.svg
+            description: ''
+            label_examples: []
             tags:
               - key: NODULE
                 name: Nodule
@@ -468,6 +490,8 @@ def test_sync_with_changed_dataset_and_reused_task(prepare_environment: Any) -> 
           - key: FIND_NODULES
             name: Find nodules
             image_path: assets/icon/kidneys_dataset_icon.svg
+            description: ''
+            label_examples: []
             tags:
               - key: NODULE
                 name: Nodule

--- a/backend/tests/functional_tests/scripts/test_sync_configuration.py
+++ b/backend/tests/functional_tests/scripts/test_sync_configuration.py
@@ -478,7 +478,7 @@ def test_sync_with_changed_dataset_and_reused_task(prepare_environment: Any) -> 
     """)
     script.sync_configuration(configuration)
 
-    # Check if description was synchronized properly
+    # Check if Datasets were synchronized properly
     datasets = DatasetsRepository.get_all_datasets(include_disabled=True)
     assert len(datasets) == 1
     kidneys = DatasetsRepository.get_dataset_by_key('KIDNEYS')

--- a/backend/tests/functional_tests/test_adding_new_label.py
+++ b/backend/tests/functional_tests/test_adding_new_label.py
@@ -21,7 +21,7 @@ def test_add_brush_label(prepare_environment: Any, synchronous_celery: Any) -> N
 
     # Step 1. Prepare a structure for the test
     DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [LabelTool.BRUSH], task.id)
 
     # Step 2. Add Scan to the system
@@ -76,7 +76,7 @@ def test_add_point_label(prepare_environment: Any, synchronous_celery: Any) -> N
 
     # Step 1. Prepare a structure for the test
     DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [LabelTool.POINT], task.id)
 
     # Step 2. Add Scan to the system
@@ -127,7 +127,7 @@ def test_add_chain_label(prepare_environment: Any, synchronous_celery: Any) -> N
 
     # Step 1. Prepare a structure for the test
     DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [LabelTool.CHAIN], task.id)
 
     # Step 2. Add Scan to the system
@@ -190,7 +190,7 @@ def test_add_chain_label_not_enough_points(prepare_environment: Any, synchronous
 
     # Step 1. Prepare a structure for the test
     DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [LabelTool.CHAIN], task.id)
 
     # Step 2. Add Scan to the system
@@ -232,8 +232,8 @@ def test_add_label_with_tag_from_other_task(prepare_environment: Any, synchronou
 
     # Step 1. Prepare a structure for the test
     DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    left_task = TasksRepository.add_task('MARK_LEFT', 'Mark Left', 'path/to/image', ['KIDNEYS'], [])
-    right_task = TasksRepository.add_task('MARK_RIGHT', 'Mark Left', 'path/to/image', ['KIDNEYS'], [])
+    left_task = TasksRepository.add_task('MARK_LEFT', 'Mark Left', 'path/to/image', ['KIDNEYS'], '', [], [])
+    right_task = TasksRepository.add_task('MARK_RIGHT', 'Mark Left', 'path/to/image', ['KIDNEYS'], '', [], [])
     LabelTagsRepository.add_new_tag('TAG_LEFT', 'Tag Left', [LabelTool.POINT], left_task.id)
     LabelTagsRepository.add_new_tag('TAG_RIGHT', 'Tag Right', [LabelTool.POINT], right_task.id)
 

--- a/backend/tests/functional_tests/test_basic_flow.py
+++ b/backend/tests/functional_tests/test_basic_flow.py
@@ -22,7 +22,7 @@ def test_basic_flow(prepare_environment: Any, synchronous_celery: Any) -> None:
 
     # Step 1. Prepare a structure for the test
     DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [LabelTool.RECTANGLE], task.id)
 
     # Step 2. Get all datasets
@@ -148,7 +148,7 @@ def test_basic_flow_with_predefined_label(prepare_environment: Any, synchronous_
 
     # Step 1. Prepare a structure for the test
     DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [LabelTool.RECTANGLE, LabelTool.BRUSH], task.id)
 
     # Step 2. Get all datasets

--- a/backend/tests/functional_tests/test_deleting_scan.py
+++ b/backend/tests/functional_tests/test_deleting_scan.py
@@ -27,7 +27,7 @@ def test_delete_scan_without_slices(prepare_environment: Any, synchronous_celery
 
     # Step 1. Prepare a structure for the test
     DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [LabelTool.RECTANGLE], task.id)
 
     # Step 2. Add Scan to the system
@@ -66,7 +66,7 @@ def test_delete_scan_with_slices(prepare_environment: Any, synchronous_celery: A
 
     # Step 1. Prepare a structure for the test
     DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [LabelTool.RECTANGLE], task.id)
 
     # Step 2. Add Scan to the system
@@ -125,7 +125,7 @@ def test_delete_scan_with_labels(prepare_environment: Any, synchronous_celery: A
 
     # Step 1. Prepare a structure for the test
     DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag',
                                     [LabelTool.RECTANGLE, LabelTool.CHAIN, LabelTool.POINT, LabelTool.BRUSH],
                                     task.id)

--- a/backend/tests/functional_tests/test_labels_repository.py
+++ b/backend/tests/functional_tests/test_labels_repository.py
@@ -18,7 +18,7 @@ def test_get_predefined_label_for_scan_in_task__no_predefined_label(prepare_envi
     """Test for fetching Predefined Label that does not exist."""
     # Step 1. Prepare a structure for the test
     dataset = DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [LabelTool.RECTANGLE], task.id)
     scan = ScansRepository.add_new_scan(dataset, 0)
 
@@ -31,7 +31,7 @@ def test_get_predefined_label_for_scan_in_task__label_that_is_not_predefined(pre
     """Test for fetching Predefined Label that is not predefined."""
     # Step 1. Prepare a structure for the test
     dataset = DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [LabelTool.RECTANGLE], task.id)
     scan = ScansRepository.add_new_scan(dataset, 0)
     user_id = UsersRepository.add_new_user(User('user@medtagger', 'HASH', 'Admin', 'Admin'))
@@ -49,7 +49,7 @@ def test_get_predefined_label_for_scan_in_task__predefined_label(prepare_environ
     """Test for fetching Predefined Label that exists."""
     # Step 1. Prepare a structure for the test
     dataset = DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [LabelTool.RECTANGLE], task.id)
     scan = ScansRepository.add_new_scan(dataset, 0)
     user_id = UsersRepository.add_new_user(User('user@medtagger', 'HASH', 'Admin', 'Admin'))
@@ -68,8 +68,8 @@ def test_get_predefined_label_for_scan_in_task__predefined_label_for_given_task(
     """Test for fetching Predefined Label only for specific Task."""
     # Step 1. Prepare a structure for the test
     dataset = DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task_left = TasksRepository.add_task('MARK_LEFT', 'Mark Left', 'path/to/image', ['KIDNEYS'], [])
-    task_right = TasksRepository.add_task('MARK_RIGHT', 'Mark Right', 'path/to/image', ['KIDNEYS'], [])
+    task_left = TasksRepository.add_task('MARK_LEFT', 'Mark Left', 'path/to/image', ['KIDNEYS'], '', [], [])
+    task_right = TasksRepository.add_task('MARK_RIGHT', 'Mark Right', 'path/to/image', ['KIDNEYS'], '', [], [])
     LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [LabelTool.RECTANGLE], task_left.id)
     scan = ScansRepository.add_new_scan(dataset, 0)
     user_id = UsersRepository.add_new_user(User('user@medtagger', 'HASH', 'Admin', 'Admin'))
@@ -92,7 +92,7 @@ def test_get_predefined_brush_label_elements(prepare_environment: Any) -> None:
     """Test for fetching Predefined Brush Label Elements."""
     # Step 1. Prepare a structure for the test
     dataset = DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     label_tag = LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [LabelTool.RECTANGLE], task.id)
     scan = ScansRepository.add_new_scan(dataset, 3)
     user_id = UsersRepository.add_new_user(User('user@medtagger', 'HASH', 'Admin', 'Admin'))

--- a/backend/tests/functional_tests/test_survey.py
+++ b/backend/tests/functional_tests/test_survey.py
@@ -22,7 +22,7 @@ def test_adding_new_survey(prepare_environment: Any) -> None:
 
     # Step 1. Prepare a structure for the test
     DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     label_tag = LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [LabelTool.RECTANGLE], task.id)
 
     # Step 2. Add an example of Survey

--- a/backend/tests/functional_tests/test_tasks.py
+++ b/backend/tests/functional_tests/test_tasks.py
@@ -21,6 +21,8 @@ def test_add_task(prepare_environment: Any) -> None:
     payload = {
         'key': 'MARK_NODULES',
         'name': 'Mark nodules',
+        'description': 'This task will focus on tagging nodules.',
+        'label_examples': ['assets/labels/label_1.png', 'assets/labels/label_2.png'],
         'image_path': 'assets/icon/my_icon.svg',
         'datasets_keys': ['KIDNEYS', 'LUNGS'],
         'tags': [{
@@ -41,6 +43,8 @@ def test_add_task(prepare_environment: Any) -> None:
     assert json_response['key'] == 'MARK_NODULES'
     assert json_response['name'] == 'Mark nodules'
     assert json_response['image_path'] == 'assets/icon/my_icon.svg'
+    assert json_response['description'] == 'This task will focus on tagging nodules.'
+    assert len(json_response['label_examples']) == 2
     assert len(json_response['tags']) == 2
     assert len(json_response['datasets_keys']) == 2
 
@@ -50,3 +54,49 @@ def test_add_task(prepare_environment: Any) -> None:
     datasets = [dataset for dataset in json_response
                 if any(task for task in dataset['tasks'] if task['key'] == 'MARK_NODULES')]
     assert len(datasets) == 2
+
+#
+# def test_get_metadata(prepare_environment: Any) -> None:
+#     """Test basic flow for retrieving metadata for Task"""
+#
+#     api_client = get_api_client()
+#     user_token = get_token_for_logged_in_user('admin')
+#
+#     # Step 1. Prepare a structure for the test
+#     DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
+#     task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+#     LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [LabelTool.RECTANGLE], task.id)
+#
+#     # Step 2. Get all datasets
+#     response = api_client.get('/api/v1/datasets', headers=get_headers(token=user_token))
+#     assert response.status_code == 200
+#     json_response = json.loads(response.data)
+#     assert isinstance(json_response, list)
+#     dataset = json_response[0]
+#     dataset_key = dataset['key']
+#     task_key = dataset['tasks'][0]['key']
+#     assert isinstance(dataset_key, str)
+#     assert len(dataset_key) > 1
+#
+#     # Step 3. Add Scan to the system
+#     payload = {'dataset': dataset_key, 'number_of_slices': 1}
+#     response = api_client.post('/api/v1/scans', data=json.dumps(payload),
+#                                headers=get_headers(token=user_token, json=True))
+#     assert response.status_code == 201
+#     json_response = json.loads(response.data)
+#     assert isinstance(json_response, dict)
+#     scan_id = json_response['scan_id']
+#     assert isinstance(scan_id, str)
+#     assert len(scan_id) >= 1
+#
+#     # Step 4. Send slices
+#     with open('tests/assets/example_scan/slice_1.dcm', 'rb') as image:
+#         response = api_client.post('/api/v1/scans/{}/slices'.format(scan_id), data={
+#             'image': (image, 'slice_1.dcm'),
+#         }, content_type='multipart/form-data', headers=get_headers(token=user_token))
+#     assert response.status_code == 201
+#     json_response = json.loads(response.data)
+#     assert isinstance(json_response, dict)
+#     slice_id = json_response['slice_id']
+#     assert isinstance(slice_id, str)
+#     assert len(slice_id) >= 1

--- a/backend/tests/functional_tests/test_tasks.py
+++ b/backend/tests/functional_tests/test_tasks.py
@@ -46,6 +46,9 @@ def test_add_task(prepare_environment: Any) -> None:
     assert json_response['key'] == 'MARK_NODULES'
     assert json_response['name'] == 'Mark nodules'
     assert json_response['image_path'] == 'assets/icon/my_icon.svg'
+    assert json_response['number_of_available_scans'] == 0
+    assert len(json_response['label_examples']) == 2
+    assert json_response['description'] == 'This task will focus on tagging nodules.'
     assert len(json_response['tags']) == 2
     assert len(json_response['datasets_keys']) == 2
 
@@ -68,7 +71,7 @@ def test_add_task(prepare_environment: Any) -> None:
         assert response.status_code == 201
 
     # Step 4. Check for Task metadata through the REST API
-    response = api_client.get('/api/v1/tasks/MARK_NODULES/metadata', headers=get_headers(token=user_token, json=True))
+    response = api_client.get('/api/v1/tasks/MARK_NODULES', headers=get_headers(token=user_token, json=True))
     assert response.status_code == 200
     json_response = json.loads(response.data)
     assert isinstance(json_response, dict)

--- a/backend/tests/functional_tests/test_tasks.py
+++ b/backend/tests/functional_tests/test_tasks.py
@@ -1,4 +1,5 @@
 """Tests for management of Tasks."""
+import glob
 import json
 from typing import Any
 
@@ -11,7 +12,7 @@ from tests.functional_tests import get_api_client, get_headers
 from tests.functional_tests.conftest import get_token_for_logged_in_user
 
 
-def test_add_task(prepare_environment: Any) -> None:
+def test_add_task(prepare_environment: Any, synchronous_celery: Any) -> None:
     """Test application with basic flow."""
     api_client = get_api_client()
     user_token = get_token_for_logged_in_user('admin')
@@ -60,15 +61,24 @@ def test_add_task(prepare_environment: Any) -> None:
     assert len(datasets) == 2
 
     # Step 4. Add Scans to datasets
-    for _ in range(2):
-        payload = {'dataset': 'KIDNEYS', 'number_of_slices': 1}
-        response = api_client.post('/api/v1/scans', data=json.dumps(payload),
-                                   headers=get_headers(token=user_token, json=True))
-        assert response.status_code == 201
-        payload = {'dataset': 'LUNGS', 'number_of_slices': 1}
-        response = api_client.post('/api/v1/scans', data=json.dumps(payload),
-                                   headers=get_headers(token=user_token, json=True))
-        assert response.status_code == 201
+    payload = {'dataset': 'KIDNEYS', 'number_of_slices': 1}
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
+                               headers=get_headers(token=user_token, json=True))
+    assert response.status_code == 201
+    json_response = json.loads(response.data)
+    scan_id = json_response['scan_id']
+    payload = {'dataset': 'LUNGS', 'number_of_slices': 1}
+    response = api_client.post('/api/v1/scans', data=json.dumps(payload),
+                               headers=get_headers(token=user_token, json=True))
+    assert response.status_code == 201
+
+    # Step 3. Send Slices
+    for file in glob.glob('tests/assets/example_scan/*.dcm'):
+        with open(file, 'rb') as image:
+            response = api_client.post('/api/v1/scans/{}/slices'.format(scan_id), data={
+                'image': (image, 'slice_1.dcm'),
+            }, headers=get_headers(token=user_token, multipart=True))
+            assert response.status_code == 201
 
     # Step 4. Check for Task metadata through the REST API
     response = api_client.get('/api/v1/tasks/MARK_NODULES', headers=get_headers(token=user_token, json=True))
@@ -77,6 +87,6 @@ def test_add_task(prepare_environment: Any) -> None:
     assert isinstance(json_response, dict)
     assert json_response['key'] == 'MARK_NODULES'
     assert json_response['name'] == 'Mark nodules'
-    assert json_response['number_of_available_scans'] == 4
+    assert json_response['number_of_available_scans'] == 1
     assert len(json_response['label_examples']) == 2
     assert json_response['description'] == 'This task will focus on tagging nodules.'

--- a/backend/tests/functional_tests/test_tasks.py
+++ b/backend/tests/functional_tests/test_tasks.py
@@ -3,9 +3,8 @@ import glob
 import json
 from typing import Any
 
-
 from medtagger.repositories import (
-    datasets as DatasetsRepository
+    datasets as DatasetsRepository,
 )
 
 from tests.functional_tests import get_api_client, get_headers

--- a/backend/tests/functional_tests/test_tasks.py
+++ b/backend/tests/functional_tests/test_tasks.py
@@ -2,7 +2,10 @@
 import json
 from typing import Any
 
-from medtagger.repositories import datasets as DatasetsRepository
+
+from medtagger.repositories import (
+    datasets as DatasetsRepository
+)
 
 from tests.functional_tests import get_api_client, get_headers
 from tests.functional_tests.conftest import get_token_for_logged_in_user
@@ -54,49 +57,3 @@ def test_add_task(prepare_environment: Any) -> None:
     datasets = [dataset for dataset in json_response
                 if any(task for task in dataset['tasks'] if task['key'] == 'MARK_NODULES')]
     assert len(datasets) == 2
-
-#
-# def test_get_metadata(prepare_environment: Any) -> None:
-#     """Test basic flow for retrieving metadata for Task"""
-#
-#     api_client = get_api_client()
-#     user_token = get_token_for_logged_in_user('admin')
-#
-#     # Step 1. Prepare a structure for the test
-#     DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-#     task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
-#     LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [LabelTool.RECTANGLE], task.id)
-#
-#     # Step 2. Get all datasets
-#     response = api_client.get('/api/v1/datasets', headers=get_headers(token=user_token))
-#     assert response.status_code == 200
-#     json_response = json.loads(response.data)
-#     assert isinstance(json_response, list)
-#     dataset = json_response[0]
-#     dataset_key = dataset['key']
-#     task_key = dataset['tasks'][0]['key']
-#     assert isinstance(dataset_key, str)
-#     assert len(dataset_key) > 1
-#
-#     # Step 3. Add Scan to the system
-#     payload = {'dataset': dataset_key, 'number_of_slices': 1}
-#     response = api_client.post('/api/v1/scans', data=json.dumps(payload),
-#                                headers=get_headers(token=user_token, json=True))
-#     assert response.status_code == 201
-#     json_response = json.loads(response.data)
-#     assert isinstance(json_response, dict)
-#     scan_id = json_response['scan_id']
-#     assert isinstance(scan_id, str)
-#     assert len(scan_id) >= 1
-#
-#     # Step 4. Send slices
-#     with open('tests/assets/example_scan/slice_1.dcm', 'rb') as image:
-#         response = api_client.post('/api/v1/scans/{}/slices'.format(scan_id), data={
-#             'image': (image, 'slice_1.dcm'),
-#         }, content_type='multipart/form-data', headers=get_headers(token=user_token))
-#     assert response.status_code == 201
-#     json_response = json.loads(response.data)
-#     assert isinstance(json_response, dict)
-#     slice_id = json_response['slice_id']
-#     assert isinstance(slice_id, str)
-#     assert len(slice_id) >= 1

--- a/backend/tests/functional_tests/test_tools_and_tags.py
+++ b/backend/tests/functional_tests/test_tools_and_tags.py
@@ -22,7 +22,7 @@ def test_add_label_non_existing_tag(prepare_environment: Any) -> None:
 
     # Step 1. Prepare a structure for the test
     DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     LabelTagsRepository.add_new_tag('LEFT_KIDNEY', 'Left Kidney', [LabelTool.RECTANGLE], task.id)
 
     # Step 2. Add Scan to the system
@@ -61,7 +61,7 @@ def test_add_label_non_supported_tool(prepare_environment: Any) -> None:
 
     # Step 1. Prepare a structure for the test
     DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     LabelTagsRepository.add_new_tag('LEFT_KIDNEY', 'Left Kidney', [LabelTool.RECTANGLE], task.id)
 
     # Step 2. Add Scan to the system
@@ -101,7 +101,7 @@ def test_add_label_missing_tag(prepare_environment: Any) -> None:
 
     # Step 1. Prepare a structure for the test
     DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     LabelTagsRepository.add_new_tag('LEFT_KIDNEY', 'Left Kidney', [LabelTool.RECTANGLE], task.id)
 
     # Step 2. Add Scan to the system
@@ -140,7 +140,7 @@ def test_add_label_missing_tool(prepare_environment: Any) -> None:
 
     # Step 1. Prepare a structure for the test
     DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     LabelTagsRepository.add_new_tag('LEFT_KIDNEY', 'Left Kidney', [LabelTool.RECTANGLE], task.id)
 
     # Step 2. Add Scan to the system
@@ -179,7 +179,7 @@ def test_add_label_wrong_tool_for_tag(prepare_environment: Any) -> None:
 
     # Step 1. Prepare a structure for the test
     DatasetsRepository.add_new_dataset('KIDNEYS', 'Kidneys')
-    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], [])
+    task = TasksRepository.add_task('MARK_KIDNEYS', 'Mark Kidneys', 'path/to/image', ['KIDNEYS'], '', [], [])
     LabelTagsRepository.add_new_tag('LEFT_KIDNEY', 'Left Kidney', [LabelTool.RECTANGLE], task.id)
 
     # Step 1. Add Scan to the system

--- a/backend/tests/functional_tests/test_users.py
+++ b/backend/tests/functional_tests/test_users.py
@@ -109,7 +109,7 @@ def test_ownership(prepare_environment: Any, synchronous_celery: Any) -> None:
 
     # Step 1. Prepare a structure for the test
     DatasetsRepository.add_new_dataset('LUNGS', 'Lungs')
-    task = TasksRepository.add_task('FIND_NODULES', 'Find Nodules', 'path/to/image', ['LUNGS'], [])
+    task = TasksRepository.add_task('FIND_NODULES', 'Find Nodules', 'path/to/image', ['LUNGS'], '', [], [])
     LabelTagsRepository.add_new_tag('EXAMPLE_TAG', 'Example Tag', [LabelTool.RECTANGLE], task.id)
     admin_id, _ = create_user(ADMIN_EMAIL, ADMIN_PASSWORD, ADMIN_FIRST_NAME, ADMIN_LAST_NAME)
     set_user_role(admin_id, 'admin')


### PR DESCRIPTION
## Proposed Changes

  - Created DB migration adding a `description` and `label_examples` columns to the DB. Additionaly created property `number_of_available_scans` to a Task table.
  - Extended existing endpoint for returning the metadata
  - Created and updated existins tests

## API changes (optional)

When creating a task there is now an option to provide both description and the label_examples (which is just an arrary of strings). The fields are `optional`. The new schema looks like this.

```
{
  "key": "string",
  "name": "string",
  "image_path": "string",
  "datasets_keys": [
    "string"
  ],
  "description": "string",
  "label_examples": [
    "string"
  ],
  "tags": [
    {
      "key": "string",
      "name": "string",
      "actions_ids": [
        0
      ],
      "tools": [
        "string"
      ]
    }
  ]
}
```

Already existing endpoint has been extended - `tasks/{task_key}` which will return the following information about a task (addition of `description`, `label_examples` and `number_of_available_scans`:
```
{
  "key": "string",
  "name": "string",
  "image_path": "string",
  "tags": [
    {
      "key": "string",
      "name": "string",
      "actions_ids": [
        0
      ],
      "tools": [
        "string"
      ]
    }
  ],
  "number_of_available_scans": 0,
  "description": "string",
  "label_examples": [
    "string"
  ],
  "datasets_keys": [
    "string"
  ]
}
```


