### PR TITLE
Explicit locale path for ngx-translate

### DIFF
--- a/frontend/src/app/main/app.module.ts
+++ b/frontend/src/app/main/app.module.ts
@@ -61,7 +61,7 @@ import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { ConfirmDialogComponent } from '../dialogs/confirm-dialog.component';
 
 export function HttpLoaderFactory(http: HttpClient) {
-    return new TranslateHttpLoader(http);
+    return new TranslateHttpLoader(http, './assets/i18n/', '.json');
 }
 
 @NgModule({


### PR DESCRIPTION
Fixes problem with localization resouce loading when serving medtagger using subdirectory.

## Proposed Changes

  - _Explicit configuration for `TranslateLoader` to search for relative asset directory_

## Additional comment (optional)

_Local reproduction possible using:_
`ng serve --base-href /medtagger/ `
