### PR TITLE
Directory upload restore. Fixed typerror in front tests.

### DIFF
--- a/frontend/src/app/components/upload-scans-selector/upload-scans-selector.component.html
+++ b/frontend/src/app/components/upload-scans-selector/upload-scans-selector.component.html
@@ -8,7 +8,7 @@
 </section>
 
 <section *ngIf="multipleScans">
-    <input type="file" (change)="onNativeInputFileSelect($event)" #inputFile hidden multiple disabled directory/>
+    <input type="file" (change)="onNativeInputFileSelect($event)" #inputFile webkitdirectory hidden multiple directory/>
     <button type="button" mat-raised-button (click)="selectFile()">
         <mat-icon>folder</mat-icon>
         <span [hidden]="scans.length">{{ 'COMPONENT.UPLOAD_SELECTOR.SELECT_DIR' | translate }}</span>

--- a/frontend/src/app/components/upload-scans-selector/upload-scans-selector.component.ts
+++ b/frontend/src/app/components/upload-scans-selector/upload-scans-selector.component.ts
@@ -143,7 +143,11 @@ export class UploadScansSelectorComponent {
             return Promise.resolve();
         }
 
-        return this.prepareSingleScan();
+        if (!this.multipleScans) {
+            return this.prepareSingleScan();
+        }
+
+        return this.prepareMultipleScans();
     }
 
     private prepareSingleScan(): Promise<void> {
@@ -188,7 +192,7 @@ export class UploadScansSelectorComponent {
         const promises: Array<Promise<any>> = [];
 
         for (const selectedFile of this.userSelectedFiles) {
-            const slicePath = ''; // selectedFile.webkitRelativePath;
+            const slicePath = selectedFile['webkitRelativePath'];
             const currentScanDirectory = slicePath.split('/').slice(0, -1).join('/');
             let scanForThisSlice = this.scans.find((scan: SelectedScan) => {
                 return scan.directory === currentScanDirectory;

--- a/frontend/src/app/mocks/selection.mock.ts
+++ b/frontend/src/app/mocks/selection.mock.ts
@@ -9,13 +9,7 @@ export class SelectionMock extends SliceSelection {
     }
 
     getAdditionalData(): Object {
-        return {
-            EXAMPLE_PARAM_1: 1337,
-            EXAMPLE_PARAM_2: this.labelTool + this.labelTag.key,
-            EXAMPLE_PARAM_3: {
-                EXAMPLE_PARAM_3_1: 'Example'
-            }
-        };
+        return {};
     }
 
     toJSON(): Object {


### PR DESCRIPTION
## Proposed Changes

  - Directory upload restored  (Multiple scans upload mode)
  - Fixed typerrors in selection service testing by simplifying selection mock.

## Additional comment (optional)

Connected with #635 . Directory upload is based upon relative webkit path mechanism which is selectively supported by browsers.
